### PR TITLE
fix: uses the default logger if none was provided

### DIFF
--- a/src/reporter.js
+++ b/src/reporter.js
@@ -30,7 +30,7 @@ class HtmlReporter extends WDIOReporter {
         super(opts);
         this.options = opts;
         if (!this.options.LOG) {
-            this.options.LOG = logger.getLogger("default") ;
+            this.options.LOG = logger;
         }
         const dir = this.options.outputDir + 'screenshots' ;
 


### PR DESCRIPTION
Bug fix for #37 .