### PR TITLE
change ReportAggregator.createReport to sync

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,9 +99,7 @@ webdriver.io will call the reporter for each test suite.  It does not aggregate 
     },
     
     onComplete: function(exitCode, config, capabilities, results) {
-        (async () => {
-            await reportAggregator.createReport();
-        })();
+        reportAggregator.createReport();
     },
     
 ``` 

--- a/src/reportAggregator.ts
+++ b/src/reportAggregator.ts
@@ -71,7 +71,7 @@ class ReportAggregator {
         return walk(this.options.outputDir, [".json"]);
     }
 
-    async createReport() {
+    createReport() {
         this.options.LOG.info("Report Aggregation started");
         let metrics = new Metrics () ;
 


### PR DESCRIPTION
I can't find a reason why `reportAggregator.createReport` is `async`. The way it's being implemented in `onComplete` could potentially lead to a race condition which could cause the tests to complete before the report aggregator has had a chance to do its job.

* Remove `async` from `ReportAggregator.createReport`
* Update `onComplete` implementation in `README.md`