### PR TITLE
Fixes empty Assertion block due to AssertionError

### DIFF
--- a/src/htmlReporter.ts
+++ b/src/htmlReporter.ts
@@ -282,8 +282,15 @@ export default class HtmlReporter extends WDIOReporter {
         if (test.errors) {
             //@ts-ignore
             for (let i = test.errorIndex; i < test.errors.length; i++) {
+                let errorObj = test.errors[i];
+                if (test.errors[i].stack.includes("AssertionError")) {
+                  errorObj = {
+                    message: test.errors[i].message.split("      \n").shift(),
+                    stack: test.errors[i].stack,
+                  };
+                }
                 //@ts-ignore
-                test.events.push(new InternalReportEvent('Error', test.errors[i]));
+                test.events.push(new InternalReportEvent('Error', errorObj));
             }
             //@ts-ignore
             test.errorIndex = test.errors.length;


### PR DESCRIPTION
Chaijs test error is of type 'AssertionError' which is not a regular object and cannot be used same as regular 'Error'. 
This fix is to display chaijs errors in HTML report. 
Also fixes https://github.com/rpii/wdio-html-reporter/issues/66 (AssertionError formating).